### PR TITLE
Full FromIterator implementation

### DIFF
--- a/src/combo_vec.rs
+++ b/src/combo_vec.rs
@@ -890,12 +890,13 @@ impl<T, const N: usize> IntoIterator for ComboVec<T, N> {
     }
 }
 
-impl<T> FromIterator<T> for ComboVec<T, 0> {
+impl<T, const N: usize> FromIterator<T> for ComboVec<T, N> {
     #[inline]
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut iter = iter.into_iter();
         Self {
-            arr: ReArr::new(),
-            vec: iter.into_iter().collect(),
+            arr: ReArr::from_iter_ref(&mut iter),
+            vec: iter.collect(),
         }
     }
 }

--- a/src/re_arr.rs
+++ b/src/re_arr.rs
@@ -221,6 +221,25 @@ impl<T, const N: usize> ReArr<T, N> {
         Self { arr, arr_len: N }
     }
 
+    // Create a new [`ReArr`] from an iterator reference, taking up to N items
+    // 
+    // Allows for initialization without consuming the iterator, leaving its
+    // remaining content for another procedure.
+    // 
+    // This is useful for ComboVec::from_iter, which needs to initialise both
+    // a ReArr and a Vec.
+    pub(crate) fn from_iter_ref(iter: &mut impl Iterator<Item = T>) -> Self {
+        let mut re_arr = Self::new();
+        for _ in 0..N {
+            if let Some(val) = iter.next() {
+                re_arr.push(val);
+                continue;
+            }
+            break;
+        }
+        re_arr
+    }
+
     /// Push an element to the end of the array.
     ///
     /// ## Panics
@@ -789,6 +808,13 @@ impl<T, const N: usize> IntoIterator for ReArr<T, N> {
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.arr.into_iter().flatten()
+    }
+}
+
+impl<T, const N: usize> FromIterator<T> for ReArr<T, N> {
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        ReArr::from_iter_ref(&mut iter.into_iter())
     }
 }
 

--- a/tests/combo_vec.rs
+++ b/tests/combo_vec.rs
@@ -31,6 +31,32 @@ fn make_new() {
 }
 
 #[test]
+fn from_iter() {
+    // Empty iterator
+    let cv = std::iter::empty().collect::<ComboVec<i32, 4>>();
+    assert_eq!(cv.len(), 0);
+    assert_eq!(cv.get(0), None);
+
+    // Iterator shorter than array
+    let cv = (1..=3).collect::<ComboVec<i32, 4>>();
+    assert_eq!(cv.len(), 3);
+    assert_eq!(cv.get(0), Some(&1));
+    assert_eq!(cv.get(1), Some(&2));
+    assert_eq!(cv.get(2), Some(&3));
+    assert_eq!(cv.get(3), None);
+
+    // Iterator longer than array
+    let cv = (1..=5).collect::<ComboVec<i32, 4>>();
+    assert_eq!(cv.len(), 5);
+    assert_eq!(cv.get(0), Some(&1));
+    assert_eq!(cv.get(1), Some(&2));
+    assert_eq!(cv.get(2), Some(&3));
+    assert_eq!(cv.get(3), Some(&4));
+    assert_eq!(cv.get(4), Some(&5));
+    assert_eq!(cv.get(5), None);
+}
+
+#[test]
 fn iter() {
     let mut cv = DEFAULT_TEST_REARR;
     cv.push(4);

--- a/tests/re_arr.rs
+++ b/tests/re_arr.rs
@@ -30,6 +30,31 @@ fn make_new() {
 }
 
 #[test]
+fn from_iter() {
+    // Empty iterator
+    let cv = std::iter::empty().collect::<ReArr<i32, 4>>();
+    assert_eq!(cv.len(), 0);
+    assert_eq!(cv.get(0), None);
+
+    // Iterator shorter than array
+    let cv = (1..=3).collect::<ReArr<i32, 4>>();
+    assert_eq!(cv.len(), 3);
+    assert_eq!(cv.get(0), Some(&1));
+    assert_eq!(cv.get(1), Some(&2));
+    assert_eq!(cv.get(2), Some(&3));
+    assert_eq!(cv.get(3), None);
+
+    // Iterator longer than array
+    let cv = (1..=5).collect::<ReArr<i32, 4>>();
+    assert_eq!(cv.len(), 4);
+    assert_eq!(cv.get(0), Some(&1));
+    assert_eq!(cv.get(1), Some(&2));
+    assert_eq!(cv.get(2), Some(&3));
+    assert_eq!(cv.get(3), Some(&4));
+    assert_eq!(cv.get(4), None);
+}
+
+#[test]
 fn iter() {
     let mut cv = DEFAULT_TEST_REARR;
     cv.push(4);


### PR DESCRIPTION
Full FromIterator implementation supporting ReArr<_, N> and ComboVec<_, N> targets.

This is useful for collecting from an iterator where you know you're likely to have just a few elements,  but support allocation for outliers. For example: `let edges = self.iter_edges(...).collect::<ComboVec<_, 8>>()`. To my mind, this aligns well with the vision of the crate.

To support this, I've added a private function `ReArr::from_iter_ref(...)` which allows for initialisation of `ReArr` without consuming the iterator, leaving its remaining content for the initialisation of the `Vec` part of `ComboVec`. It's private because I felt it was fairly non-idomatic as compared with standard library.

Additional tests have been added.